### PR TITLE
Missing semicolons for MMult_1x4_<6,7,8,9>.c

### DIFF
--- a/src/MMult_1x4_6.c
+++ b/src/MMult_1x4_6.c
@@ -6,7 +6,7 @@
 
 /* Routine for computing C = A * B + C */
 
-void AddDot1x4( int, double *, int,  double *, int, double *, int )
+void AddDot1x4( int, double *, int,  double *, int, double *, int );
 
 void MY_MMult( int m, int n, int k, double *a, int lda, 
                                     double *b, int ldb,

--- a/src/MMult_1x4_7.c
+++ b/src/MMult_1x4_7.c
@@ -6,7 +6,7 @@
 
 /* Routine for computing C = A * B + C */
 
-void AddDot1x4( int, double *, int,  double *, int, double *, int )
+void AddDot1x4( int, double *, int,  double *, int, double *, int );
 
 void MY_MMult( int m, int n, int k, double *a, int lda, 
                                     double *b, int ldb,

--- a/src/MMult_1x4_8.c
+++ b/src/MMult_1x4_8.c
@@ -6,7 +6,7 @@
 
 /* Routine for computing C = A * B + C */
 
-void AddDot1x4( int, double *, int,  double *, int, double *, int )
+void AddDot1x4( int, double *, int,  double *, int, double *, int );
 
 void MY_MMult( int m, int n, int k, double *a, int lda, 
                                     double *b, int ldb,

--- a/src/MMult_1x4_9.c
+++ b/src/MMult_1x4_9.c
@@ -6,7 +6,7 @@
 
 /* Routine for computing C = A * B + C */
 
-void AddDot1x4( int, double *, int,  double *, int, double *, int )
+void AddDot1x4( int, double *, int,  double *, int, double *, int );
 
 void MY_MMult( int m, int n, int k, double *a, int lda, 
                                     double *b, int ldb,


### PR DESCRIPTION
Fixed missing semicolons for following files:

- `MMult_1x4_6.c`
- `MMult_1x4_7.c`
- `MMult_1x4_8.c`
- `MMult_1x4_9.c`