### PR TITLE
Add missing loop over block columns of C

### DIFF
--- a/src/HowToOptimizeGemm/parameters.h
+++ b/src/HowToOptimizeGemm/parameters.h
@@ -35,6 +35,6 @@ leading dimension of the array that stores matrix X.  If LDX=-1
 then the leading dimension is set to the row dimension of matrix X.
 */
 
-#define LDA 1000
-#define LDB 1000
-#define LDC 1000
+#define LDA -1
+#define LDB -1
+#define LDC -1

--- a/src/MMult_4x4_15.c
+++ b/src/MMult_4x4_15.c
@@ -22,15 +22,17 @@ void MY_MMult( int m, int n, int k, double *a, int lda,
                                     double *b, int ldb,
                                     double *c, int ldc )
 {
-  int i, p, pb, ib;
+  int i, p, pb, ib, j, jb;
 
-  /* This time, we compute a mc x n block of C by a call to the InnerKernel */
-
-  for ( p=0; p<k; p+=kc ){
-    pb = min( k-p, kc );
-    for ( i=0; i<m; i+=mc ){
-      ib = min( m-i, mc );
-      InnerKernel( ib, n, pb, &A( i,p ), lda, &B(p, 0 ), ldb, &C( i,0 ), ldc, i==0 );
+  /* This time, we compute a mc x nb block of C by a call to the InnerKernel */
+  for ( j=0; j<n; j+=nb ){
+    jb = min( n-j, nb );
+    for ( p=0; p<k; p+=kc ){
+      pb = min( k-p, kc );
+      for ( i=0; i<m; i+=mc ){
+        ib = min( m-i, mc );
+        InnerKernel( ib, jb, pb, &A( i,p ), lda, &B(p,j ), ldb, &C( i,j ), ldc, i==0 );
+      }
     }
   }
 }


### PR DESCRIPTION
The block column width of C is defined by `#define nb 1000` and used to allocate the buffers, but otherwise `nb` is unused. 
As a result, if the m-by-n matrix C has `n` > `nb`, the code encounters a segmentation fault.  This commit fixes this issue by

* adding the missing loop over the block columns of C, and
* adjusting the default leading dimensions to whatever the row count is.